### PR TITLE
change docker repo for sonarr

### DIFF
--- a/dinaren_server/docker-compose.yaml
+++ b/dinaren_server/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
 
   sonarr-beta:
-    image: hotio/sonarr
+    image: linuxserver/sonarr
     container_name: sonarr-beta
     extends:
       file: base.yml


### PR DESCRIPTION
Linuxserver proved to be more stable docker repo. So changing the sonarr to use it